### PR TITLE
Update inline script metadata to example notebooks

### DIFF
--- a/notebooks/bookshelf.py
+++ b/notebooks/bookshelf.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#     "marimo>=0.19.7",
+#     "marimo-cad", 
+# ]
+# ///
 """Parametric Bookshelf - marimo-cad example."""
 
 import marimo

--- a/notebooks/vase.py
+++ b/notebooks/vase.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#     "marimo>=0.19.7",
+#     "marimo-cad", 
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.6"


### PR DESCRIPTION
This allows running the notebooks directly with `uvx marimo edit notebooks/vase.py`. Before it would automatically resolve to Python 3.14 which isn't supported by all the dependencies. 

Cool project though! I am on the marimo team and will make a reference to this on our YT today 👍 